### PR TITLE
Implement KafkaConsumer according to instructions

### DIFF
--- a/src/main/java/com/ing/be/tia/processor/MessageProcessorFacade.java
+++ b/src/main/java/com/ing/be/tia/processor/MessageProcessorFacade.java
@@ -18,8 +18,7 @@ public class MessageProcessorFacade {
     /**
      * Delegates the given {@link Message} to the first {@link MessageProcessor}
      * that indicates it can process the message's type.
-     * <p>
-     * No SWITCH-CASE or IF-ELSE is used; instead, the correct processor is
+     * The correct processor is
      * dynamically selected based on the {@link MessageProcessor#canProcess}
      * contract.
      *

--- a/src/main/java/com/ing/be/tia/processor/MessageProcessorFacade.java
+++ b/src/main/java/com/ing/be/tia/processor/MessageProcessorFacade.java
@@ -1,0 +1,34 @@
+package com.ing.be.tia.processor;
+
+import com.ing.be.tia.data.Message;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class MessageProcessorFacade {
+
+    private final List<MessageProcessor> processors;
+
+    public MessageProcessorFacade(final List<MessageProcessor> processors) {
+        this.processors = processors;
+    }
+
+    /**
+     * Delegates the given {@link Message} to the first {@link MessageProcessor}
+     * that indicates it can process the message's type.
+     * <p>
+     * No SWITCH-CASE or IF-ELSE is used; instead, the correct processor is
+     * dynamically selected based on the {@link MessageProcessor#canProcess}
+     * contract.
+     *
+     * @param message the message to process, must not be {@code null}
+     */
+    public void process(@NonNull final Message message) {
+        processors.stream()
+                .filter(p -> p.canProcess(message.type()))
+                .findFirst()
+                .ifPresent(p -> p.process(message));
+    }
+}

--- a/src/main/java/com/ing/be/tia/service/KafkaConsumer.java
+++ b/src/main/java/com/ing/be/tia/service/KafkaConsumer.java
@@ -9,7 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
-
+import com.ing.be.tia.processor.MessageProcessorFacade;
 import java.util.concurrent.ArrayBlockingQueue;
 
 @Component
@@ -18,11 +18,12 @@ public class KafkaConsumer {
     private static final Logger LOGGER = LoggerFactory.getLogger(KafkaConsumer.class);
     private final ArrayBlockingQueue<Message> queue = new ArrayBlockingQueue<>(100);
     private final ObjectMapper mapper;
-
+    private final MessageProcessorFacade messageProcessorFacade;
     // HINT: might need to inject more dependencies here
     @Autowired
-    public KafkaConsumer(final ObjectMapper mapper) {
+    public KafkaConsumer(final ObjectMapper mapper, final MessageProcessorFacade messageProcessorFacade) {
         this.mapper = mapper;
+        this.messageProcessorFacade = messageProcessorFacade;
     }
 
     @KafkaListener(topics = "${spring.kafka.topic}")
@@ -35,6 +36,9 @@ public class KafkaConsumer {
         // See EmbeddedKafkaIntegrationTest.performActionsFromMultipleMessagesInAnyOrder()
         // HINT: use Facade Design Pattern to delegate message processing to appropriate processor.
         // HINT: you have to create a new class for that.
+
+        // Delegates handling to facade (no switch-case / if-else here)
+        messageProcessorFacade.process(message);
     }
 
     public ArrayBlockingQueue<Message> getQueue() {


### PR DESCRIPTION
Added the missing implementation inside KafkaConsumer, created MessageProcessorFacade, delegated processing to processors without switch-case. and executed the test  EmbeddedKafkaIntegrationTest#performActionsFromMultipleMessagesInAnyOrder

